### PR TITLE
Fix GoDoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ bix
 
 Tabix files in go.
 
-[![GoDoc] (https://godoc.org/github.com/brentp/bix?status.png)](https://godoc.org/github.com/brentp/bix)
+[![GoDoc](https://godoc.org/github.com/brentp/bix?status.png)](https://godoc.org/github.com/brentp/bix)
 
 
 `Bix`is a pure go tabix reader. Tabix has a minimum resolution of 16K bases. So, for dense annotations


### PR DESCRIPTION
Markdown doesn't allow spaces in the image link